### PR TITLE
Suggested fix to default barcode issue

### DIFF
--- a/js/barcodes.js
+++ b/js/barcodes.js
@@ -1,7 +1,9 @@
 window.addEventListener("load",e=>{
+  const DEFAULT_BARCODE = "95000000"; // more obvious that this is the default since it looks funny
+  
   var barcodeul=document.querySelector('#barcode'),
   add=document.querySelector('#addbarcode'),
-  barcodes=[[localize('you'), "95012345"]],
+  barcodes=[[localize('you'), DEFAULT_BARCODE]],
   barcodeelems=[];
   let code = cookie.getItem('[gunn-web-app] barcode.ids');
   if (code) {
@@ -13,7 +15,7 @@ window.addEventListener("load",e=>{
   function updateSave() {
     cookie.setItem('[gunn-web-app] barcode.ids', 'A' + JSON.stringify(barcodeelems.map(([a, b])=>[a.value, b.value])));
   }
-  function newBarcodeLi([name = localize('barcode-default'), code = "95012345"] = []) {
+  function newBarcodeLi([name = localize('barcode-default'), code = DEFAULT_BARCODE] = []) {
     var li=document.createElement("li"),
     divcanvas=document.createElement("div"),
     input=document.createElement("input"),


### PR DESCRIPTION
Creates a variable DEFAULT_BARCODE == "95000000" for convenience, and changes it from "95012345" which resolves to a (potentially former) PAUSD student.